### PR TITLE
Fix 'originalEvent' error on Chrome mobile

### DIFF
--- a/src/rangeSlider.js
+++ b/src/rangeSlider.js
@@ -721,11 +721,16 @@
             if (typeof e.pageX !== 'undefined') {
                 pageX = (e.touches && e.touches.length) ? e.touches[0].pageX : e.pageX;
             }
-            else if (typeof e.originalEvent.clientX !== 'undefined') {
-                pageX = e.originalEvent.clientX;
+            else if (typeof e.originalEvent !== 'undefined') {
+                if (typeof e.originalEvent.clientX !== 'undefined') {
+                    pageX = e.originalEvent.clientX;
+                }
+                else if (e.originalEvent.touches && e.originalEvent.touches[0] && typeof e.originalEvent.touches[0].clientX !== 'undefined') {
+                    pageX = e.originalEvent.touches[0].clientX;
+                }
             }
-            else if (e.originalEvent.touches && e.originalEvent.touches[0] && typeof e.originalEvent.touches[0].clientX !== 'undefined') {
-                pageX = e.originalEvent.touches[0].clientX;
+            else if (e.touches && e.touches[0] && typeof e.touches[0].clientX !== 'undefined') {
+                pageX = e.touches[0].clientX;
             }
             else if (e.currentPoint && typeof e.currentPoint.x !== 'undefined') {
                 pageX = e.currentPoint.x;


### PR DESCRIPTION
There is a bug on Chrome Mobile, we can't slide.
It occurs in the __getRelativePosition()_ method because the **originalEvent** object in the **event** object is _undefined_.

``` javascript
if (typeof e.originalEvent.clientX !== 'undefined') {
    pageX = e.originalEvent.clientX;
}
else if (e.originalEvent.touches && e.originalEvent.touches[0] && typeof e.originalEvent.touches[0].clientX !== 'undefined') {
    pageX = e.originalEvent.touches[0].clientX;
}
```

_Line 724_

Here the error thrown : 

> Cannot read property 'clientX' of undefined
### The fixes
- Test if _originalEvent_ exists
- Add a test for _e.touches_ and get its value if necessary

``` javascript
else if (e.touches && e.touches[0] && typeof e.touches[0].clientX !== 'undefined') {
    pageX = e.touches[0].clientX;
}
```

Seb
