### PR TITLE
fix(setPosition): fix typo when updating position

### DIFF
--- a/src/rangeSlider.js
+++ b/src/rangeSlider.js
@@ -672,7 +672,7 @@
             this.value = value;
             this._updatePercentFromValue();
 
-            if (this.isInteractsNow || this.needTriggerEventss) {
+            if (this.isInteractsNow || this.needTriggerEvents) {
                 if (this.onSlideStart && typeof this.onSlideStart === 'function' && this.onSlideEventsCount === 0) {
                     this.onSlideStart(this.value, this.percent, this.position);
                 }


### PR DESCRIPTION
Hi Sergii,
just came across a little typo.

- Makes sure that the callbacks are fired when the slider value is updated manually like this: `slider.rangeSlider.update({value: someValue}, true);`

Greets
Malte