### PR TITLE
Include webkitTransform for older Android devices

### DIFF
--- a/src/range-slider.js
+++ b/src/range-slider.js
@@ -430,10 +430,12 @@ export default class RangeSlider {
     if (this.vertical) {
       this.container.style.height = (position + this.grabX) + 'px';
       this.handle.style.transform = 'translateY(-' + position + 'px)';
+      this.handle.style['-webkit-transform'] = 'translateY(-' + position + 'px)';
       this.handle.style['-ms-transform'] = 'translateY(-' + position + 'px)';
     } else {
       this.container.style.width = (position + this.grabX) + 'px';
       this.handle.style.transform = 'translateX(' + position + 'px)';
+      this.handle.style['-webkit-transform'] = 'translateX(' + position + 'px)';
       this.handle.style['-ms-transform'] = 'translateX(' + position + 'px)';
     }
 


### PR DESCRIPTION
Android WebViews in versions before 5.0 do not get updated via the Play Store, so this vendor prefixed `transform` is needed.