### PR TITLE
enhance: display handle on the very front w/o setting z-index

### DIFF
--- a/src/range-slider.js
+++ b/src/range-slider.js
@@ -121,8 +121,8 @@ export default class RangeSlider {
     this.range = document.createElement('div');
     dom.addClass(this.range, this.options.rangeClass);
     this.range.id = this.identifier;
-    this.range.appendChild(this.handle);
     this.range.appendChild(this.container);
+    this.range.appendChild(this.handle);
 
     directionClass = this.vertical ? this.options.rangeClass + '__vertical' : this.options.rangeClass + '__horizontal';
     dom.addClass(this.range, directionClass);
@@ -302,7 +302,7 @@ export default class RangeSlider {
 
     dom.forEachAncestors(el, el =>
       (isEventOnSlider = el.id === this.identifier && !dom.hasClass(el, this.options.disabledClass)),
-    true);
+      true);
 
     if (isEventOnSlider) {
       this._handleDown(ev, data);
@@ -341,7 +341,7 @@ export default class RangeSlider {
       this._setBufferPosition(this.options.buffer);
     }
     this._updatePercentFromValue();
-    dom.triggerEvent(this.element, 'change', {origin: this.identifier});
+    dom.triggerEvent(this.element, 'change', { origin: this.identifier });
   }
 
   _handleResize() {
@@ -393,7 +393,7 @@ export default class RangeSlider {
     dom.removeEventListeners(document, this.options.endEvent, this._handleEnd);
 
     // Ok we're done fire the change event
-    dom.triggerEvent(this.element, 'change', {origin: this.identifier});
+    dom.triggerEvent(this.element, 'change', { origin: this.identifier });
 
     if (this.isInteractsNow || this.needTriggerEvents) {
       if (this.onSlideEnd && typeof this.onSlideEnd === 'function') {
@@ -584,6 +584,6 @@ export default class RangeSlider {
     // Set the new value and fire the `input` event
     this.element.value = value;
     this.value = value;
-    dom.triggerEvent(this.element, 'input', {origin: this.identifier});
+    dom.triggerEvent(this.element, 'input', { origin: this.identifier });
   }
 }


### PR DESCRIPTION
I hope I can use this module w/o setting z-index.

Technically, yes I can set z-index as like the demo(.css).

But...The thing is .....Setting z-index has several side effects.

Especially, when the page already has complicated layouts by ordering z-index on many elements.

I couldn't use z-index in this situation...That's very bizarre 😢...

Following Images are initialized w/o z-index style.

AS-IS
<img width="290" alt="as-is" src="https://user-images.githubusercontent.com/25364015/47547162-56568080-d92f-11e8-83b0-ad5546ec293e.png">

By changing the order of two elements like the` file changed`, you gonna put the handle in front of the container `without setting z-index` like below.

TO-BE
![to-be](https://user-images.githubusercontent.com/25364015/47547170-5bb3cb00-d92f-11e8-9848-b045e4b69f28.png)
